### PR TITLE
Set strinct_negotiation in Response class to False.

### DIFF
--- a/src/feat/web/webserver.py
+++ b/src/feat/web/webserver.py
@@ -1596,7 +1596,7 @@ class Response(log.Logger):
 
     implements(IWebResponse, document.IWritableDocument)
 
-    strict_negotiation = True
+    strict_negotiation = False
 
     # map encodings unknown to Python but used by browsers to what Python
     # knows how to handle


### PR DESCRIPTION
This way the server won't respond with a NOT_ACCEPTABLE 406 when the Accept header isn't sent.
